### PR TITLE
Move trap to remove the temp files to the correct position

### DIFF
--- a/bin/dz-build.js
+++ b/bin/dz-build.js
@@ -65,9 +65,7 @@ function build(options) {
 			return
 		}
 
-		var cmds = [
-			"trap '{ rm -f $DZ_MANIFEST $DZ_MCV }' EXIT"
-		]
+		var cmds = []
 		var temporary_vm = false
 		if(!(base_vm)) {
 			if(!(base_img)) {
@@ -104,6 +102,7 @@ function build(options) {
 				"name": manifest.name,
 				"version": manifest.version
 			})))
+			cmds.push("trap \"rm -f ${DZ_MANIFEST} ${DZ_MCV}\" EXIT")
 
 			var result_handler = ''
 			if(output_path) {


### PR DESCRIPTION
The variables `DZ_MANIFEST` and `DZ_MCV` are not set at the first point so they are empty. Also the `{}` are the wrong command you may would like to use `()` to run in a sub-shell but this isn't required by the command.
