### PR TITLE
Provide error logfile output to imgadm and to the user

### DIFF
--- a/bin/dz-create-mcv.sh
+++ b/bin/dz-create-mcv.sh
@@ -31,7 +31,8 @@ header() {
 	echo 'set -o pipefail'
 	echo 'set -o nounset'
 	echo 'export PATH=/opt/local/bin:/opt/local/sbin:/usr/bin:/usr/sbin'
-	echo 'trap "mdata-put prepare-image:state error" ERR'
+	echo 'function dzerror { mdata-put prepare-image:state error; tail -n +1 "/var/svc/log/system-zoneinit:default.log" "/var/svc/log/smartdc-mdata:execute.log" | mdata-put prepare-image:error; }'
+	echo 'trap dzerror ERR'
 	echo 'mdata-put prepare-image:state running'
 }
 


### PR DESCRIPTION
It's easier to use a simple bash function to do the trap handling.
I'm using tail as a cat replacement because it also return the filename
as header information.

Example output:

```
imgadm: error (PrepareImageError): prepare-image script error while preparing VM 57e580d9-df0d-4511-96a1-6a8799c827ba:
    ...
    ==> /var/svc/log/system-zoneinit:default.log <==
    [ Mar 28 13:25:29 Enabled. ]
    [ Mar 28 13:25:34 Executing start method ("/opt/local/lib/svc/method/zoneinit"). ]
    + . /lib/svc/share/smf_include.sh
    ++ SMF_EXIT_OK=0
    ++ SMF_EXIT_NODAEMON=94
...

    ==> /var/svc/log/smartdc-mdata:execute.log <==
    [ Mar 28 13:25:29 Disabled. ]
    [ Mar 28 13:25:53 Disabled. ]
    [ Mar 28 13:25:56 Enabled. ]
    [ Mar 28 13:26:00 Executing start method ("/opt/local/lib/svc/method/mdata-execute"). ]
    [2015-03-28T13:26:00Z] /opt/local/lib/svc/method/mdata-execute:32: '[' -f /lib/svc/method/mdata-execute ']'
    [2015-03-28T13:26:00Z] /opt/local/lib/svc/method/mdata-execute:32: exec /lib/svc/method/mdata-execute
    [2015-03-28T13:26:00Z] /lib/svc/method/mdata-execute:29: . /lib/svc/share/smf_include.sh
    [[2015-03-28T13:26:00Z] /lib/svc/share/smf_include.sh:242: SMF_EXIT_OK=0
    [[2015-03-28T13:26:00Z] /lib/svc/share/smf_include.sh:243: SMF_EXIT_NODAEMON=94
    [[2015-03-28T13:26:00Z] /lib/svc/share/smf_include.sh:244: SMF_EXIT_ERR_FATAL=95
    [[2015-03-28T13:26:00Z] /lib/svc/share/smf_include.sh:245: SMF_EXIT_ERR_CONFIG=96
    [[2015-03-28T13:26:00Z] /lib/svc/share/smf_include.sh:246: SMF_EXIT_MON_DEGRADE=97
    [[2015-03-28T13:26:00Z] /lib/svc/share/smf_include.sh:247: SMF_EXIT_MON_OFFLINE=98
    [[2015-03-28T13:26:00Z] /lib/svc/share/smf_include.sh:248: SMF_EXIT_ERR_NOSMF=99
    [[2015-03-28T13:26:00Z] /lib/svc/share/smf_include.sh:249: SMF_EXIT_ERR_PERM=100
    [2015-03-28T13:26:00Z] /lib/svc/method/mdata-execute:30: smf_is_globalzone
    [2015-03-28T13:26:00Z] /lib/svc/share/smf_include.sh:64: smf_is_globalzone(): '[' 57e580d9-df0d-4511-96a1-6a8799c827ba = global ']'
    [2015-03-28T13:26:00Z] /lib/svc/share/smf_include.sh:65: smf_is_globalzone(): return 1
    [2015-03-28T13:26:00Z] /lib/svc/method/mdata-execute:34: '[' -f /var/svc/provisioning ']'
    [2015-03-28T13:26:00Z] /lib/svc/method/mdata-execute:35: mv /var/svc/provisioning /var/svc/provision_success
    [2015-03-28T13:26:00Z] /lib/svc/method/mdata-execute:38: [[ -x /var/svc/mdata-operator-script ]]
    [2015-03-28T13:26:00Z] /lib/svc/method/mdata-execute:47: user_script_exit=0
    [2015-03-28T13:26:00Z] /lib/svc/method/mdata-execute:48: '[' -x /var/svc/mdata-user-script ']'
    [2015-03-28T13:26:00Z] /lib/svc/method/mdata-execute:53: exit 0
    [ Mar 28 13:26:01 Method "start" exited with status 0. ]
    [ Mar 28 13:26:05 Stopping because service disabled. ]
    [ Mar 28 13:26:05 Executing stop method (null). ]
    [ Mar 28 13:26:31 Enabled. ]
    [ Mar 28 13:26:38 Executing start method ("/opt/local/lib/svc/method/mdata-execute"). ]
    [2015-03-28T13:26:38Z] /opt/local/lib/svc/method/mdata-execute:32: '[' -f /lib/svc/method/mdata-execute ']'
    [2015-03-28T13:26:38Z] /opt/local/lib/svc/method/mdata-execute:32: exec /lib/svc/method/mdata-execute
    [2015-03-28T13:26:38Z] /lib/svc/method/mdata-execute:29: . /lib/svc/share/smf_include.sh
    [[2015-03-28T13:26:38Z] /lib/svc/share/smf_include.sh:242: SMF_EXIT_OK=0
    [[2015-03-28T13:26:38Z] /lib/svc/share/smf_include.sh:243: SMF_EXIT_NODAEMON=94
    [[2015-03-28T13:26:38Z] /lib/svc/share/smf_include.sh:244: SMF_EXIT_ERR_FATAL=95
    [[2015-03-28T13:26:38Z] /lib/svc/share/smf_include.sh:245: SMF_EXIT_ERR_CONFIG=96
    [[2015-03-28T13:26:38Z] /lib/svc/share/smf_include.sh:246: SMF_EXIT_MON_DEGRADE=97
    [[2015-03-28T13:26:38Z] /lib/svc/share/smf_include.sh:247: SMF_EXIT_MON_OFFLINE=98
    [[2015-03-28T13:26:38Z] /lib/svc/share/smf_include.sh:248: SMF_EXIT_ERR_NOSMF=99
    [[2015-03-28T13:26:38Z] /lib/svc/share/smf_include.sh:249: SMF_EXIT_ERR_PERM=100
    [2015-03-28T13:26:38Z] /lib/svc/method/mdata-execute:30: smf_is_globalzone
    [2015-03-28T13:26:38Z] /lib/svc/share/smf_include.sh:64: smf_is_globalzone(): '[' 57e580d9-df0d-4511-96a1-6a8799c827ba = global ']'
    [2015-03-28T13:26:38Z] /lib/svc/share/smf_include.sh:65: smf_is_globalzone(): return 1
    [2015-03-28T13:26:38Z] /lib/svc/method/mdata-execute:34: '[' -f /var/svc/provisioning ']'
    [2015-03-28T13:26:38Z] /lib/svc/method/mdata-execute:38: [[ -x /var/svc/mdata-operator-script ]]
    [2015-03-28T13:26:38Z] /lib/svc/method/mdata-execute:39: /var/svc/mdata-operator-script
    /var/svc/mdata-operator-script: line 755: xxx: command not found    
```
