### PR TITLE
Disable SSH connection sharing because it breaks the build process

### DIFF
--- a/bin/dz-build
+++ b/bin/dz-build
@@ -178,7 +178,7 @@ function build(options) {
 				cmds.push("vmadm delete " + base_vm)
 			}
 			cmds.push("exit ${status}")
-			var p = spawn("ssh", [host, "bash"], {stdio: ['pipe', process.stdout, process.stderr]})
+			var p = spawn("ssh", ["-S", "none", host, "bash"], {stdio: ['pipe', process.stdout, process.stderr]})
 			p.stdin.write(cmds.join("\n"))
 			p.stdin.end("\n")
 			p.on('exit', function(code, signal) {


### PR DESCRIPTION
The `-S` option with the parameter `none` disable connection sharing for SSH. The problem is pipeing fails with the spawned ssh connection because of some timeout I think.

If you disable connection sharing for the SSH connection everything is working fine. This is only required if you use ControlMaster in your ~/.ssh/config file. The extra parameter will not break anything.
