### PR TITLE
Create logfile limit, last 100 lines - because mdata limit

### DIFF
--- a/bin/dz-create-mcv.sh
+++ b/bin/dz-create-mcv.sh
@@ -31,7 +31,7 @@ header() {
 	echo 'set -o pipefail'
 	echo 'set -o nounset'
 	echo 'export PATH=/opt/local/bin:/opt/local/sbin:/usr/bin:/usr/sbin'
-	echo 'function dzerror { mdata-put prepare-image:state error; tail -n +1 "/var/svc/log/system-zoneinit:default.log" "/var/svc/log/smartdc-mdata:execute.log" | mdata-put prepare-image:error; }'
+	echo 'function dzerror { tail -n 100 "/var/svc/log/system-zoneinit:default.log" "/var/svc/log/smartdc-mdata:execute.log" | mdata-put prepare-image:error; mdata-put prepare-image:state error; }'
 	echo 'trap dzerror ERR'
 	echo 'mdata-put prepare-image:state running'
 }


### PR DESCRIPTION
If the information to mdata is to big or long you receive an errror
`receive timeout, resetting protocol`. I've also re-order the commands
to first paste the error log and set the state after that.
