### PR TITLE
min_ram and max_ram are required as integers in the JSON output

### DIFF
--- a/bin/dz-build
+++ b/bin/dz-build
@@ -140,10 +140,10 @@ function build(options) {
 				"tags": {}
 			}
 			if(manifest.minram) {
-				img_manifest.requirements['min_ram'] = manifest.minram
+				img_manifest.requirements['min_ram'] = parseInt(manifest.minram)
 			}
 			if(manifest.maxram) {
-				img_manifest.requirements['max_ram'] = manifest.maxram
+				img_manifest.requirements['max_ram'] = parseInt(manifest.maxram)
 			}
 
 			if(manifest.customer_metadata) {


### PR DESCRIPTION
I convert the input information for min_ram and max_ram to integer. If this isn't done the following error happen from `imgadm`:

```
imgadm create: error (ManifestValidation): invalid manifest: requirements.min_ram (invalid image "requirements.min_ram" (not a positive integer): "1024")
```
