### PR TITLE
Set default network to one public network and allow the user the opti…

### DIFF
--- a/bin/dz-build
+++ b/bin/dz-build
@@ -136,8 +136,18 @@ function build(options) {
 				"version":     manifest.version,
 				"description": manifest.description,
 				"homepage":    manifest.homepage,
-				"requirements": {},
+				"requirements": {
+					"networks": [
+						{
+							"description": "public",
+							"name": "net0"
+						}
+					]
+				},
 				"tags": {}
+			}
+			if(manifest.requirements) {
+				img_manifest.requirements = manifest.requirements
 			}
 			if(manifest.minram) {
 				img_manifest.requirements['min_ram'] = parseInt(manifest.minram)


### PR DESCRIPTION
…on to overwrite requirements

This should fix #7. It allow the user to overwrite all requirements based on the `manifest.json`. If no `requirements.networks` are set we use the default of one network interface. If `minram` is used it will be added to the requirements as well but could be overwritten by the `requirements` list.
