### PR TITLE
remove name collision

### DIFF
--- a/bin/dz-shell
+++ b/bin/dz-shell
@@ -16,9 +16,9 @@ if(program.args < 1) {
 	process.exit(1)
 }
 
-console(program)
+shell(program)
 
-function console(options) {
+function shell(options) {
 	var host = options.host
 	var uuid = options.args[0]
 	

--- a/package.json
+++ b/package.json
@@ -23,5 +23,5 @@
   },
   "description": "deployment utility for zones",
   "name": "deploy-zone",
-  "version": "0.0.8"
+  "version": "0.0.9"
 }


### PR DESCRIPTION
Renames the console function to shell to avoid clashing with globals