### PR TITLE
add support for specifying a user when connecting

### DIFF
--- a/bin/dz
+++ b/bin/dz
@@ -11,5 +11,5 @@ program
 	.command('stop <uuid>', 'stop vm')
 	.command('host', 'manage hosts')
 	.command('upgrade <uuid>', 'reprovision to new image')
-	.command('shell [-C] <uuid>', 'connect to console')
+	.command('shell [-C|-u user] <uuid>', 'connect to console')
 	.parse(process.argv)

--- a/bin/dz-shell
+++ b/bin/dz-shell
@@ -9,6 +9,7 @@ program
 	.option('-h, --host [host]', 'use host')
 	.option('-C, --console', 'connects to the zone console')
 	.option('-s, --ssh', 'connect with ssh to the hostname')
+	.option('-u, --user [user]', 'connect with the specified user')
 	.parse(process.argv)
 
 if(program.args < 1) {
@@ -20,6 +21,7 @@ shell(program)
 
 function shell(options) {
 	var host = options.host
+	var user = options.user
 	var uuid = options.args[0]
 	
 	if(!(host)) {
@@ -33,6 +35,8 @@ function shell(options) {
 		spawn("ssh", ['-t', host, "vmadm", "console", uuid], { stdio: 'inherit' })
 	} else if(options.ssh){
 		//spawn("ssh", ['-t', host, "vmadm", "console", uuid], { stdio: 'inherit' })
+	} else if(options.user) {
+		spawn("ssh", ['-t', host, "zlogin", "-l", user, uuid], { stdio: 'inherit' })
 	} else {
 		spawn("ssh", ['-t', host, "zlogin", uuid], { stdio: 'inherit' })
 	}


### PR DESCRIPTION
When connecting to a zone it is now possible to also tell as which user you want to connect to the machine.

``dz shell -u bluemaex UUID``