### PR TITLE
Fix issue for `dz list` command

### DIFF
--- a/bin/dz
+++ b/bin/dz
@@ -21,7 +21,7 @@ function help() {
   process.exit(1)
 }
 
-if (!process.argv[3]) {
+if (!process.argv[2]) {
   help()
 }
 


### PR DESCRIPTION
We've commands and parameters which do not require additional options or parameters. So for `dz list` the help was shown every time. We should limit the help page if no parameter is set or it's not exists