### PR TITLE
fix wrong path resolution when installed globally

### DIFF
--- a/bin/dz
+++ b/bin/dz
@@ -21,11 +21,11 @@ function help() {
   process.exit(1)
 }
 
-if (!process.argv[3]) {
+if (!process.argv[2]) {
   help()
 }
 
-var executable = process.argv[1] + '-' + process.argv[2]
+var executable = __dirname + '/dz-' + process.argv[2]
 var args = process.argv.slice(3)
 
 var child = spawn(executable, args, { stdio: 'inherit', detached: true })

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "dz": "./bin/dz",
     "dz-host": "./bin/dz-host",
     "dz-list": "./bin/dz-list",
+    "dz-images": "./bin/dz-images",
     "dz-shell": "./bin/dz-shell",
     "dz-start": "./bin/dz-start",
     "dz-stop": "./bin/dz-stop",
@@ -23,5 +24,5 @@
   },
   "description": "deployment utility for zones",
   "name": "deploy-zone",
-  "version": "0.1.0"
+  "version": "0.1.1"
 }


### PR DESCRIPTION
This solves:

 - show the help way too often (basically the same as https://github.com/wiedi/deploy-zone/pull/15)
 - also when installed globally we cant rely on the executable path because it is different than where the file actually lives (best example is ``dz-images``, which was  actually  not present in the ``bin`` list and thus always failed) - this should fix it and execute everything even it is not listed in the ``bin`` array)